### PR TITLE
Update compatible with gcc>=6

### DIFF
--- a/R/flags.R
+++ b/R/flags.R
@@ -79,6 +79,6 @@ itkCompileFlags <- function() {
 #' @export itkVersion
 itkVersion <- function() {
   # should update this as versions change
-  "4.10"
+  "4.9"
 }
 

--- a/R/flags.R
+++ b/R/flags.R
@@ -79,6 +79,6 @@ itkCompileFlags <- function() {
 #' @export itkVersion
 itkVersion <- function() {
   # should update this as versions change
-  "4.9"
+  "4.10"
 }
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ devtools::install_github( "stnava/ITKR" )
 ```
 The primary result of this installation process is *R*-based access to the ITK library.  The user or developer can identify the location of the ITK installation by performing:
 ```
-ITKR::getITKincludes()
+ITKR::itkIncludes()
 ```
 which uses `cat` to report the install location.  We use `cat` because it allows the developer simpler access to these variable names in Makefiles and other compilation-related scripts.  If you want to store the variable within R:
 ```
-itkinstalldir <- capture.output( ITKR::getITKincludes() )
+itkinstalldir <- capture.output( ITKR::itkIncludes() )
 ```
 This package is still an early development version.

--- a/configure
+++ b/configure
@@ -10,7 +10,7 @@ if [[ $TRAVIS -eq true ]] ; then
 fi
 cd ./src
 itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
-itktag=fc03bcc92b11326b87c232c14eb234fc1f791f9f
+itktag=63fb4dd95f56debc595c9527672beeb8fe09bb16
 mkdir  itks itkb
 if [[ ! -s itks/CMakeLists.txt ]] ; then
     git clone $itkgit itks


### PR DESCRIPTION
In my enviroment, gcc 6.1.1, I failed to install with this command.
`devtools::install_github("stnava/ITKR")`

ITK was updated that is compatible with gcc>=6. However, ITKR was using old ITK and it prevent from installing with gcc6. So, I modified ITKR for gcc>=6.

In addition, the function getITKincludes() had been deleted already and ITK use itkIncludes() now. So, I fixed description of those functions at README.md.