### PR TITLE
Fixing Travis Checks and Configure file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,12 @@ r:
   - release
   - devel
 
-matrix:
-  allow_failures:
+allow_failures:
   - r: devel
 
 latex: false
 compiler: clang
-osx_image: xcode8.2
+osx_image: xcode9
 
 env:
   global:
@@ -58,6 +57,8 @@ script:
   - if [[ ${#TRAVIS_TAG} -eq 0 ]]; 
     then 
       travis_wait 100 R CMD check ${R_CHECK_ARGS} "${PKG_FILE_NAME}" --no-manual --install-args=--build; 
+      check_fail ;
+      check_warnings ;
     fi # --as-cran
   - ls
   - mydir=${PWD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ r:
   - release
   - devel
 
-allow_failures:
-  - r: devel
+matrix: 
+  allow_failures:
+    - r: devel
 
 latex: false
 compiler: clang

--- a/configure
+++ b/configure
@@ -38,16 +38,16 @@ echo "ITK;${itktag}" >> ../data/softwareVersions.csv
 mkdir -p itkb
 cd itkb
 compflags=" -fPIC -O2  "
-cmaker=`Rscript -e "x=Sys.which('cmake'); cat(x)"`
+cmaker=`${R_HOME}/bin/Rscript -e "x=Sys.which('cmake'); cat(x)"`
 if [[ -z "${cmaker}" ]]; then
-	res=`Rscript -e "cat(('cmaker' %in% installed.packages())*1)"`
+	res=`${R_HOME}/bin/Rscript -e "cat(('cmaker' %in% installed.packages())*1)"`
 	if [[ $res -eq 0 ]]; 
 		then
 	    git clone https://github.com/stnava/cmaker ;
 	    R CMD INSTALL cmaker ;
 	    rm -rf cmaker ;
 	fi
-    cmaker=`Rscript -e "x=cmaker::cmake()"`
+    cmaker=`${R_HOME}/bin/Rscript -e "x=cmaker::cmake()"`
 else
 	cmaker="cmake"
 fi


### PR DESCRIPTION
As per http://r.789695.n4.nabble.com/Error-message-Rscript-should-not-be-used-without-a-path-td4748071.html, the error `'Rscript' should not be used without a path -- see par. 1.6 of the manual` will be coming up in `R CMD check` in R 3.5.0.  

This PR should fix that in the `configure` file and also add some checks to Travis