### PR TITLE
added itk 4.13.0 release

### DIFF
--- a/R/flags.R
+++ b/R/flags.R
@@ -81,6 +81,6 @@ itkCompileFlags <- function() {
 itkVersion <- function() {
   # should update this as versions change
   # "4.11"
-  "4.12"
+  "4.13"
 }
 

--- a/configure
+++ b/configure
@@ -11,7 +11,8 @@ fi
 cd ./src
 itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
 # itktag=2714cc1805f50504f5b9a60d0f62ffec8e73989 # 4.11
-itktag=c5138560409c75408ff76bccff938f21e5dcafc6 #4.12
+# itktag=c5138560409c75408ff76bccff938f21e5dcafc6 #4.12
+itktag=d92873e33e8a54e933e445b92151191f02feab42 # 4.13
 # if ther is a directory but no git,
 # remove it
 if [[ -d itks ]]; then 

--- a/configure.win
+++ b/configure.win
@@ -7,7 +7,8 @@ CMAKE_BUILD_TYPE=Release
 cd ./src
 itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
 # itktag=2714cc1805f50504f5b9a60d0f62ffec8e73989 # 4.11
-itktag=c5138560409c75408ff76bccff938f21e5dcafc6 # 4.12
+# itktag=c5138560409c75408ff76bccff938f21e5dcafc6 # 4.12
+itktag=d92873e33e8a54e933e445b92151191f02feab42 # 4.13
 mkdir itks itkb
 git clone $itkgit itks
 mkdir -p ../data


### PR DESCRIPTION
I used the commit related to the release of ITK 4.13: https://github.com/InsightSoftwareConsortium/ITK/releases/tag/v4.13.0.  When do you think 5.0 will be coming out?  There is already an alpha level out: https://github.com/InsightSoftwareConsortium/ITK/releases.  It was about 3 months from the release candidates for 4.13 until the final release.  This may be a bit longer because it's a major version release.

May want to wait, I'm unsure.
