### PR TITLE
Will build on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# ITKR Build
 language: r
 sudo: false
 cache: packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_install:
   - wget -O ${fname} http://bit.ly/travis_helpers
   - cat ${fname}; source ${fname}; rm ${fname}  
   - export rver=`r_version`;
+  - export gh_user=`get_gh_user` ;
   - cat DESCRIPTION  
   - export PACKAGE_NAME=`package_name`
   - export RCHECK_DIR=${PACKAGE_NAME}.Rcheck  
@@ -88,6 +89,11 @@ script:
     fi
   - mv ${PKG_FILE_NAME} ${PKG_TARBALL_WITH_R} ;      
   - PKG_FILE_NAME=${PKG_TARBALL_WITH_R}
+  - if [[ "${gh_user}" == "stnava" ]]; then 
+      export secure_key=Y+JfKm3oXRUxpxyWjBtXimuBcuv3+D5iakzCwMJLqEDPjd+w9ow1x5a4GN/LfFg8Lbhflc8Uaz2bpxRuD5enk+RRmFtcXBB/IsnxkXBEM3fA2eT4ZIxq/aTt4HisOdXclyZc5PxAXFOVO8/QWcjh3boqSpOjscS0kYCWkm4KT9M= ;
+    elif [[ "${gh_user}" == "muschellij2" ]]; then 
+      export secure_key=UL/OXal9+cvomf7iDtJnAoVY8YEmVa7MECjbBrfnmGeloQ6yRhYVUk5sRlbPNM4VczdtN6/k8hH8LpN/3IT8Wqh+YxIaN0kw/0J05dzj1OLcilRKxTFtQo7i1VYqdTqytXbbvaISaVLF+0UjGIwfFARr/m/GZsKXV54wXhTFirY= ;
+    fi    
 
 
 after_failure:
@@ -114,12 +120,12 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: UL/OXal9+cvomf7iDtJnAoVY8YEmVa7MECjbBrfnmGeloQ6yRhYVUk5sRlbPNM4VczdtN6/k8hH8LpN/3IT8Wqh+YxIaN0kw/0J05dzj1OLcilRKxTFtQo7i1VYqdTqytXbbvaISaVLF+0UjGIwfFARr/m/GZsKXV54wXhTFirY=
+    secure: ${secure_key}
   file: ${PKG_FILE_NAME}
   skip_cleanup: true
   on:
     tags: true
-    repo: stnava/${PROJ_DIR}
+    repo: ${gh_user}/${PROJ_DIR}
     all_branches: true
 
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ITKR
 Type: Package
 Title: ITK in R
-Version: 0.4.16.1
-Date: 2018-08-08
+Version: 0.4.16.2
+Date: 2018-10-01
 Authors@R: c(
     person(c("Brian", "B"), "Avants", role = c("aut", "cre"), email = "stnava@gmail.com"),
     person(c("Benjamin", "M"), "Kandel", role = "ctb", email = "NA"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ITKR
 Type: Package
 Title: ITK in R
-Version: 0.4.16.2
+Version: 0.4.17
 Date: 2018-10-01
 Authors@R: c(
     person(c("Brian", "B"), "Avants", role = c("aut", "cre"), email = "stnava@gmail.com"),

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,8 @@
 
 # Download script file from GitHub
 init:
-  ps: |
+  - rm -f *.Rproj
+  - ps: |
         $ErrorActionPreference = "Stop"
         Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
@@ -12,6 +13,8 @@ environment:
     USE_RTOOLS: true    
     R_CHECK_INSTALL_ARGS: "--install-args=--build --no-multiarch"
     WARNINGS_ARE_ERRORS: 1
+    CRAN: http://cran.rstudio.com
+
   matrix:
     - R_VERSION: devel
       R_VER: 3.6
@@ -20,7 +23,6 @@ environment:
       R_VER: 3.5
 
     - R_VERSION: oldrel
-      CRAN: http://cran.rstudio.com
       R_VER: 3.4
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 # DO NOT CHANGE the "init" and "install" sections below
 
+build: off
+
 # Download script file from GitHub
 init:
   - rm -f *.Rproj

--- a/configure
+++ b/configure
@@ -11,8 +11,9 @@ fi
 cd ./src
 # itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
 # itktag=8e821376ee7e19d81c29741acdc32bcda911eafc # Jacobian registration speedup
-itkgit=https://github.com/stnava/ITK.git
-itktag=f44174c188466da6a9dcfbf3928d52bbd3b05cd2
+# itkgit=https://github.com/stnava/ITK.git
+itkgit=https://github.com/muschellij2/ITK.git
+itktag=e84f2b1fe6e127acaff52acf9428c2aa514e6a23 # latest
 # if there is a directory but no git,
 # remove it
 if [[ -d itks ]]; then

--- a/configure.win
+++ b/configure.win
@@ -8,7 +8,7 @@ cd ./src
 # itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
 # itktag=b2f5227b9f8d44cb155176f5dbcad6f911206841 # most up to date
 itkgit=https://github.com/stnava/ITK.git
-itktag=f44174c188466da6a9dcfbf3928d52bbd3b05cd2
+itktag=22ef020347e60f2b42648083ccebfadbf780f823
 # itktag= # latest
 mkdir itks itkb
 # as per https://discourse.itk.org/t/path-length-limitation-in-windows-lifted/545/12

--- a/configure.win
+++ b/configure.win
@@ -5,11 +5,10 @@ CXX=`R CMD config CXX`
 JTHREADS=1
 CMAKE_BUILD_TYPE=Release
 cd ./src
-# itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
-# itktag=b2f5227b9f8d44cb155176f5dbcad6f911206841 # most up to date
-itkgit=https://github.com/stnava/ITK.git
-# itktag=22ef020347e60f2b42648083ccebfadbf780f823
-itktag= # latest
+itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
+itktag=22ef020347e60f2b42648083ccebfadbf780f823
+# itkgit=https://github.com/stnava/ITK.git
+# itktag= # latest
 mkdir itks itkb
 # as per https://discourse.itk.org/t/path-length-limitation-in-windows-lifted/545/12
 longpaths=`git config --get core.longpaths`

--- a/configure.win
+++ b/configure.win
@@ -8,8 +8,8 @@ cd ./src
 # itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
 # itktag=b2f5227b9f8d44cb155176f5dbcad6f911206841 # most up to date
 itkgit=https://github.com/stnava/ITK.git
-itktag=22ef020347e60f2b42648083ccebfadbf780f823
-# itktag= # latest
+# itktag=22ef020347e60f2b42648083ccebfadbf780f823
+itktag= # latest
 mkdir itks itkb
 # as per https://discourse.itk.org/t/path-length-limitation-in-windows-lifted/545/12
 longpaths=`git config --get core.longpaths`

--- a/configure.win
+++ b/configure.win
@@ -5,10 +5,10 @@ CXX=`R CMD config CXX`
 JTHREADS=1
 CMAKE_BUILD_TYPE=Release
 cd ./src
-itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
+# itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
 # itktag=22ef020347e60f2b42648083ccebfadbf780f823
-# itkgit=https://github.com/stnava/ITK.git
-itktag= # latest
+itkgit=https://github.com/muschellij2/ITK.git
+itktag=e84f2b1fe6e127acaff52acf9428c2aa514e6a23 # latest
 mkdir itks itkb
 # as per https://discourse.itk.org/t/path-length-limitation-in-windows-lifted/545/12
 longpaths=`git config --get core.longpaths`

--- a/configure.win
+++ b/configure.win
@@ -6,9 +6,9 @@ JTHREADS=1
 CMAKE_BUILD_TYPE=Release
 cd ./src
 itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
-itktag=22ef020347e60f2b42648083ccebfadbf780f823
+# itktag=22ef020347e60f2b42648083ccebfadbf780f823
 # itkgit=https://github.com/stnava/ITK.git
-# itktag= # latest
+itktag= # latest
 mkdir itks itkb
 # as per https://discourse.itk.org/t/path-length-limitation-in-windows-lifted/545/12
 longpaths=`git config --get core.longpaths`


### PR DESCRIPTION
With the changes to ITK, which I have a PR out https://github.com/stnava/ITK/pulls.  The patch from https://github.com/InsightSoftwareConsortium/ITK/issues/66 now allows v5 to work on windows.  

Thus, if we build ITKR from stnava (with a tag), it should go into releases, and be able to make another go at ANTsRCore on Windows.    I will try to build ANTsRCore now using ITK v5, a binary ITKR that uses that, and review the results on https://ci.appveyor.com/project/muschellij2/antsrcore