### PR TITLE
added GNUmake to SystemRequirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ LazyLoad: yes
 Imports: Rcpp
 LinkingTo: Rcpp
 NeedsCompilation: yes
-SystemRequirements: cmake, git, clang
+SystemRequirements: cmake, git, clang, GNUmake
 URL: http://github.com/stnava/ITKR/
 BugReports: http://github.com/stnava/ITKR/issues
 RoxygenNote: 6.0.1.9000


### PR DESCRIPTION
This will fix the warning that is currently failing ITKR (for R-release) on neuroconductor (https://travis-ci.com/neuroconductor-devel/ITKR/builds/113767807)
```
Portable Makefiles do not use GNU extensions such as +=, :=, $(shell),
$(wildcard), ifeq ... endif, .NOTPARALLEL
```
See here for the testing logs: https://travis-ci.com/adigherman/ITKR/builds/113891470

Fix was based on this: https://github.com/RcppCore/RcppParallel/issues/53