### PR TITLE
GNU make

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ LazyLoad: yes
 Imports: Rcpp
 LinkingTo: Rcpp
 NeedsCompilation: yes
-SystemRequirements: cmake, git, clang, GNUmake
+SystemRequirements: cmake, git, clang, GNU make
 URL: http://github.com/stnava/ITKR/
 BugReports: http://github.com/stnava/ITKR/issues
 RoxygenNote: 6.0.1.9000


### PR DESCRIPTION
Changed `GNUmake` into `GNU make`. This time, the warning did go away (https://travis-ci.com/adigherman/ITKR/builds/114627680)